### PR TITLE
Fixed missing return for rotor 2+3's rotate()

### DIFF
--- a/Modern_Cryptography/Enigma/Python_Enigma/Rotor2.py
+++ b/Modern_Cryptography/Enigma/Python_Enigma/Rotor2.py
@@ -21,3 +21,5 @@ def rotate():
     if rotor[0] == notch:
         turnOver = True
     rotor = rotor[1:] + rotor[0]
+    
+    return turnOver

--- a/Modern_Cryptography/Enigma/Python_Enigma/Rotor3.py
+++ b/Modern_Cryptography/Enigma/Python_Enigma/Rotor3.py
@@ -1,4 +1,3 @@
-
 #Rotor III
 alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 rotor = "BDFHJLCPRTXVZNYEIWGAKMUSQO"
@@ -22,3 +21,5 @@ def rotate():
     if rotor[0] == notch:
         turnOver = True
     rotor = rotor[1:] + rotor[0]
+
+    return turnOver


### PR DESCRIPTION
In Rotor2 and Rotor3, the rotate() functions are missing a `return turnOver` statement which affects the operation of the Enigma machine.